### PR TITLE
select: fleshed out a basic implementation of select

### DIFF
--- a/execute.hpp
+++ b/execute.hpp
@@ -1,10 +1,19 @@
 #ifndef EXECUTE
 #define EXECUTE
 
+#include <streambuf>
+
 #include "types.hpp"
 
 void execute_create(CreateStatement);
 void execute_insert(InsertStatement);
 void execute_select(SelectStatement);
+
+class db_row_buffer : public std::streambuf {
+ public:
+  db_row_buffer(char* start, size_t size) {
+    this->setg(start, start, start + size);
+  }
+};
 
 #endif

--- a/parse.cpp
+++ b/parse.cpp
@@ -59,6 +59,9 @@ SelectStatement parse_select(const std::string &select_stmt) {
     if (select_stmt[idx] == ',' || std::isblank(select_stmt[idx])) {
       if (!token.empty() && token != "from") {
         response.add_attribute(token);
+        if (token == "*") {
+          response.set_select_all(true);
+        }
       }
       idx++;
       token = "";

--- a/types.hpp
+++ b/types.hpp
@@ -54,13 +54,18 @@ class InsertStatement {
 class SelectStatement {
   std::string table_name;
   std::vector<std::string> attributes;
+  bool select_all;
 
  public:
   SelectStatement(std::string table_name, std::vector<std::string> attributes)
-      : table_name(table_name), attributes(attributes){};
+      : table_name(table_name), attributes(attributes), select_all(false){};
 
-  SelectStatement() : table_name(""), attributes(std::vector<std::string>()){};
+  SelectStatement()
+      : table_name(""),
+        attributes(std::vector<std::string>()),
+        select_all(false){};
 
+  std::string get_table_name() const { return table_name; }
   void set_table_name(const std::string &table_name) {
     this->table_name = table_name;
   }
@@ -68,6 +73,12 @@ class SelectStatement {
   void add_attribute(const std::string &attribute) {
     this->attributes.push_back(attribute);
   }
+
+  std::vector<std::string> &get_attributes() { return attributes; }
+
+  void set_select_all(const bool &select_all) { this->select_all = select_all; }
+
+  const bool &get_select_all() const { return select_all; }
 };
 
 #endif


### PR DESCRIPTION
This PR provides the ability to use the `select` query on this DB. Duplicate types of records do not work just yet; all attributes must be of different types. `select * from table` is supported.